### PR TITLE
La inn sluttet dato på historiske sjekkhefter

### DIFF
--- a/mytxs/forms.py
+++ b/mytxs/forms.py
@@ -295,7 +295,6 @@ class SjekkhefteDatoForm(forms.Form):
             vervInnehavelseAktiv('', dato=dato),
             stemmegruppeVerv(includeDirr=True),
             medlem=medlem,
-            verv__kor__navn=korNavn
         ).exists():
             return True
 

--- a/mytxs/models.py
+++ b/mytxs/models.py
@@ -344,6 +344,15 @@ class MedlemQuerySet(models.QuerySet):
             ))
         )
 
+    def annotateSluttetDato(self, kor):
+        return self.annotate(
+            sluttet=VervInnehavelse.objects.filter(
+                stemmegruppeVerv(includeDirr=True),
+                korLookup(kor, 'verv__kor'),
+                medlem=OuterRef('pk')
+            ).order_by('-start').values('slutt')[:1]
+        )
+
     def annotateFravær(self, kor, heleSemesteret=False):
         'Annotater umeldtFravær, ugyldigFravær, gyldigFravær og hendelseVarighet'
         def getDateTime(fieldName, backupDateFieldName=None):

--- a/mytxs/templates/mytxs/sjekkheftet.html
+++ b/mytxs/templates/mytxs/sjekkheftet.html
@@ -68,6 +68,14 @@
         {% endif %}
         {% endif %}
         
+        {% if sjekkheftetDatoForm.getDato %}
+        {% if medlem.sluttet %}
+        <li>Sluttet: {{ medlem.sluttet }}</li>
+        {% else %}
+        <li>Fortsatt aktiv</li>
+        {% endif %}
+        {% endif %}
+
         {% if medlem.public__fødselsdato %}
         <li>Fødselsdato: {{ medlem.public__fødselsdato }}</li>
         {% endif %}

--- a/mytxs/views.py
+++ b/mytxs/views.py
@@ -237,6 +237,9 @@ def sjekkheftet(request, side, underside=None):
             kor=kor if kor.navn != consts.Kor.Sangern else None
         )
 
+        if dato:
+            request.queryset = request.queryset.annotateSluttetDato(kor=kor)
+
         if tilgang := Tilgang.objects.filter(sjekkheftetSynlig=True, navn=underside, kor=kor).first():
             # Om det e en tilgangsdefinert undergruppe vi ser på, f.eks. styret
             request.queryset = request.queryset.filter(
@@ -245,7 +248,7 @@ def sjekkheftet(request, side, underside=None):
                 vervInnehavelser__verv__tilganger=tilgang
             )
 
-            if dato == None:
+            if not dato:
                 request.queryset = request.queryset.annotatePublic(
                     overrideVisible=request.user.medlem.tilganger.filter(navn=consts.Tilgang.sjekkhefteSynlig, kor=kor).exists()
                 )
@@ -260,8 +263,8 @@ def sjekkheftet(request, side, underside=None):
                 vervInnehavelseAktiv(dato=dato),
                 vervInnehavelser__verv__kor=kor
             ).annotateStemmegruppe(kor, includeDirr=True, dato=dato)
-            
-            if dato == None:
+
+            if not dato:
                 request.queryset = request.queryset.annotatePublic(
                     overrideVisible=request.user.medlem.tilganger.filter(navn=consts.Tilgang.sjekkhefteSynlig, kor=kor).exists()
                 )


### PR DESCRIPTION
Fikset også at man bare må ha vært aktiv i ett av korene, har ikke noe å si om hvilket kor når man ser på et annet historisk sjekkhefte. Føles greit ut det:)